### PR TITLE
refund_id doesn't exist in \Klarna\Rest\OrderManagement\Order

### DIFF
--- a/src/Klarna/Rest/OrderManagement/Order.php
+++ b/src/Klarna/Rest/OrderManagement/Order.php
@@ -104,7 +104,10 @@ class Order extends Resource
         if (isset($this['refunds'])) {
             $refunds = [];
             foreach ($this['refunds'] as $refund) {
-                $refundId = $refund[Refund::ID_FIELD];
+                $refundId = null;
+                if (isset($refund[Refund::ID_FIELD])) {
+                    $refundId = $refund[Refund::ID_FIELD];
+                }
 
                 $object = new Refund(
                     $this->connector,


### PR DESCRIPTION
`refund_id` is never mentioned in documentation (https://developers.klarna.com/api/#order-management-api-get-order)