### PR TITLE
Fix exception namespace and PHPDoc

### DIFF
--- a/src/Klarna/Rest/Transport/GuzzleConnector.php
+++ b/src/Klarna/Rest/Transport/GuzzleConnector.php
@@ -214,7 +214,7 @@ class GuzzleConnector implements ConnectorInterface
      * @param string[] $options Request options
      *
      * @throws RequestException   When an error is encountered
-     * @throws \LogicException    When the adapter does not populate a response
+     * @throws \RuntimeException  When the adapter does not populate a response
      *
      * @return ResponseInterface
      */
@@ -232,7 +232,7 @@ class GuzzleConnector implements ConnectorInterface
             return $response;
         } catch (RequestException $e) {
             throw new \RuntimeException($e->getMessage(), $e->getCode(), $e);
-        } catch (Throwable $e) {
+        } catch (\Throwable $e) {
             throw new \RuntimeException($e->getMessage(), $e->getCode(), $e);
         }
     }


### PR DESCRIPTION
`Throwable` was using incorrect namespace which caused all other exceptions than `RequestException` to fall through it, rather than being caught. This could lead to a situation where `send()` would throw other exceptions than documented in the PHPDoc block.

The PHPDoc block claimed that `send()` would throw `\LogicException`. It was fixed to say `\RuntimeException`.