### PR TITLE
Remove "src" folder from a PSR4 autoload definition as fallback directory.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "autoload": {
         "psr-4": {
-            "": "src/"
+            "Klarna\\": "src/Klarna/"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
Fix #46 