### PR TITLE
Prepare Release 4.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.2.3] - 2020-01-29
+## [4.2.3] - 2020-02-14
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.2.3] - 2020-01-29
+
+### Added
+
+- HTTP Transport: Oceania Base URLs (playground and production)
+
 
 ## [4.2.2] - 2019-11-05
 
@@ -199,7 +205,8 @@ you need to check the code before go live.
 
 - **NEW MINT-1804** Support checkout v3 and ordermanagement v1 APIs - *Joakim.L*
 
-[Unreleased]: https://github.com/klarna/kco_rest_php/compare/v4.2.2...HEAD
+[Unreleased]: https://github.com/klarna/kco_rest_php/compare/v4.2.3...HEAD
+[4.2.3]: https://github.com/klarna/kco_rest_php/compare/v4.2.2...v4.2.3
 [4.2.2]: https://github.com/klarna/kco_rest_php/compare/v4.2.1...v4.2.2
 [4.2.1]: https://github.com/klarna/kco_rest_php/compare/v4.2.0...v4.2.1
 [4.2.0]: https://github.com/klarna/kco_rest_php/compare/v4.1.5...v4.2.0

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "klarna/kco_rest",
-    "description": "Klarna Checkout PHP SDK",
+    "description": "Official Klarna REST PHP SDK",
     "homepage": "http://developers.klarna.com",
     "license": "Apache-2.0",
     "type": "library",

--- a/docs/examples/CheckoutAPI/create_checkout.php
+++ b/docs/examples/CheckoutAPI/create_checkout.php
@@ -35,6 +35,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/CheckoutAPI/create_checkout_attachment.php
+++ b/docs/examples/CheckoutAPI/create_checkout_attachment.php
@@ -37,6 +37,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/CheckoutAPI/discounts.php
+++ b/docs/examples/CheckoutAPI/discounts.php
@@ -35,6 +35,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/CheckoutAPI/fetch_checkout.php
+++ b/docs/examples/CheckoutAPI/fetch_checkout.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/CheckoutAPI/handling_exceptions.php
+++ b/docs/examples/CheckoutAPI/handling_exceptions.php
@@ -37,6 +37,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/CheckoutAPI/update_checkout.php
+++ b/docs/examples/CheckoutAPI/update_checkout.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/Common/change_user_agent.php
+++ b/docs/examples/Common/change_user_agent.php
@@ -35,6 +35,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/CustomerTokenAPI/Tokens/create_order.php
+++ b/docs/examples/CustomerTokenAPI/Tokens/create_order.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/CustomerTokenAPI/Tokens/read_token_details.php
+++ b/docs/examples/CustomerTokenAPI/Tokens/read_token_details.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/CustomerTokenAPI/Tokens/update_token_status.php
+++ b/docs/examples/CustomerTokenAPI/Tokens/update_token_status.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/HostedPaymentPageAPI/Sessions/create_new_hpp_session.php
+++ b/docs/examples/HostedPaymentPageAPI/Sessions/create_new_hpp_session.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/HostedPaymentPageAPI/Sessions/disable_session.php
+++ b/docs/examples/HostedPaymentPageAPI/Sessions/disable_session.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/HostedPaymentPageAPI/Sessions/distribute_link.php
+++ b/docs/examples/HostedPaymentPageAPI/Sessions/distribute_link.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/HostedPaymentPageAPI/Sessions/get_hpp_session_status.php
+++ b/docs/examples/HostedPaymentPageAPI/Sessions/get_hpp_session_status.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/InstantShoppingAPI/ButtonKeys/create_button_key.php
+++ b/docs/examples/InstantShoppingAPI/ButtonKeys/create_button_key.php
@@ -35,6 +35,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/InstantShoppingAPI/ButtonKeys/see_button_key_options.php
+++ b/docs/examples/InstantShoppingAPI/ButtonKeys/see_button_key_options.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/InstantShoppingAPI/ButtonKeys/update_button_key.php
+++ b/docs/examples/InstantShoppingAPI/ButtonKeys/update_button_key.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/InstantShoppingAPI/Orders/approve_order.php
+++ b/docs/examples/InstantShoppingAPI/Orders/approve_order.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/InstantShoppingAPI/Orders/decline_order.php
+++ b/docs/examples/InstantShoppingAPI/Orders/decline_order.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/InstantShoppingAPI/Orders/retrieve_order.php
+++ b/docs/examples/InstantShoppingAPI/Orders/retrieve_order.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/OrderManagementAPI/Captures/add_shipping_info.php
+++ b/docs/examples/OrderManagementAPI/Captures/add_shipping_info.php
@@ -37,6 +37,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/OrderManagementAPI/Captures/trigger_send_out.php
+++ b/docs/examples/OrderManagementAPI/Captures/trigger_send_out.php
@@ -37,6 +37,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/OrderManagementAPI/Captures/update_customer_details.php
+++ b/docs/examples/OrderManagementAPI/Captures/update_customer_details.php
@@ -37,6 +37,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/OrderManagementAPI/Orders/acknowledge_order.php
+++ b/docs/examples/OrderManagementAPI/Orders/acknowledge_order.php
@@ -39,6 +39,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/OrderManagementAPI/Orders/cancel_order.php
+++ b/docs/examples/OrderManagementAPI/Orders/cancel_order.php
@@ -38,6 +38,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/OrderManagementAPI/Orders/create_capture.php
+++ b/docs/examples/OrderManagementAPI/Orders/create_capture.php
@@ -39,6 +39,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/OrderManagementAPI/Orders/extend_authorization_time.php
+++ b/docs/examples/OrderManagementAPI/Orders/extend_authorization_time.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/OrderManagementAPI/Orders/fetch_all_captures.php
+++ b/docs/examples/OrderManagementAPI/Orders/fetch_all_captures.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/OrderManagementAPI/Orders/fetch_capture.php
+++ b/docs/examples/OrderManagementAPI/Orders/fetch_capture.php
@@ -37,6 +37,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/OrderManagementAPI/Orders/fetch_order.php
+++ b/docs/examples/OrderManagementAPI/Orders/fetch_order.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/OrderManagementAPI/Orders/release_remaining_authorization.php
+++ b/docs/examples/OrderManagementAPI/Orders/release_remaining_authorization.php
@@ -38,6 +38,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/OrderManagementAPI/Orders/update_customer_details.php
+++ b/docs/examples/OrderManagementAPI/Orders/update_customer_details.php
@@ -38,6 +38,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/OrderManagementAPI/Orders/update_merchant_references.php
+++ b/docs/examples/OrderManagementAPI/Orders/update_merchant_references.php
@@ -39,6 +39,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/OrderManagementAPI/Orders/update_order_lines.php
+++ b/docs/examples/OrderManagementAPI/Orders/update_order_lines.php
@@ -38,6 +38,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/OrderManagementAPI/Refunds/fetch_refund.php
+++ b/docs/examples/OrderManagementAPI/Refunds/fetch_refund.php
@@ -37,6 +37,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/OrderManagementAPI/Refunds/refund_order.php
+++ b/docs/examples/OrderManagementAPI/Refunds/refund_order.php
@@ -38,6 +38,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/PaymentsAPI/Orders/cancel_existing_authorization.php
+++ b/docs/examples/PaymentsAPI/Orders/cancel_existing_authorization.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/PaymentsAPI/Orders/create_order.php
+++ b/docs/examples/PaymentsAPI/Orders/create_order.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/PaymentsAPI/Orders/generate_customer_token.php
+++ b/docs/examples/PaymentsAPI/Orders/generate_customer_token.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/PaymentsAPI/Sessions/create_new_credit_session.php
+++ b/docs/examples/PaymentsAPI/Sessions/create_new_credit_session.php
@@ -35,6 +35,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/PaymentsAPI/Sessions/read_credit_session.php
+++ b/docs/examples/PaymentsAPI/Sessions/read_credit_session.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/PaymentsAPI/Sessions/update_credit_session.php
+++ b/docs/examples/PaymentsAPI/Sessions/update_credit_session.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/SettlementsAPI/Payouts/get_all_payouts.php
+++ b/docs/examples/SettlementsAPI/Payouts/get_all_payouts.php
@@ -37,6 +37,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/SettlementsAPI/Payouts/get_payout.php
+++ b/docs/examples/SettlementsAPI/Payouts/get_payout.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/SettlementsAPI/Payouts/get_summary.php
+++ b/docs/examples/SettlementsAPI/Payouts/get_summary.php
@@ -37,6 +37,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/SettlementsAPI/Reports/payout_report_csv.php
+++ b/docs/examples/SettlementsAPI/Reports/payout_report_csv.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/SettlementsAPI/Reports/payout_report_pdf.php
+++ b/docs/examples/SettlementsAPI/Reports/payout_report_pdf.php
@@ -36,6 +36,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/SettlementsAPI/Reports/summary_report_cvs.php
+++ b/docs/examples/SettlementsAPI/Reports/summary_report_cvs.php
@@ -37,6 +37,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/SettlementsAPI/Reports/summary_report_pdf.php
+++ b/docs/examples/SettlementsAPI/Reports/summary_report_pdf.php
@@ -37,6 +37,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/docs/examples/SettlementsAPI/Transactions/get_transactions.php
+++ b/docs/examples/SettlementsAPI/Transactions/get_transactions.php
@@ -35,6 +35,8 @@ EU_BASE_URL = 'https://api.klarna.com'
 EU_TEST_BASE_URL = 'https://api.playground.klarna.com'
 NA_BASE_URL = 'https://api-na.klarna.com'
 NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com'
+OC_BASE_URL = 'https://api-oc.klarna.com'
+OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com'
 */
 $apiEndpoint = Klarna\Rest\Transport\ConnectorInterface::EU_TEST_BASE_URL;
 

--- a/src/Klarna/Rest/Transport/ConnectorInterface.php
+++ b/src/Klarna/Rest/Transport/ConnectorInterface.php
@@ -54,6 +54,16 @@ interface ConnectorInterface
     const NA_TEST_BASE_URL = 'https://api-na.playground.klarna.com';
 
     /**
+     * API base URL for Oceania.
+     */
+    const OC_BASE_URL = 'https://api-oc.klarna.com';
+
+    /**
+     * Testing API base URL for Oceania.
+     */
+    const OC_TEST_BASE_URL = 'https://api-oc.playground.klarna.com';
+
+    /**
      * Sends HTTP GET request to specified path.
      *
      * @param string $path URL path.

--- a/src/Klarna/Rest/Transport/UserAgent.php
+++ b/src/Klarna/Rest/Transport/UserAgent.php
@@ -32,7 +32,7 @@ class UserAgent implements UserAgentInterface
     /**
      * Version of the SDK.
      */
-    const VERSION = '4.2.2';
+    const VERSION = '4.2.3';
 
     /**
      * Components of the user agent.


### PR DESCRIPTION
## [4.2.3] - 2020-02-14

### Added

- HTTP Transport: Oceania Base URLs (playground and production)