### PR TITLE
Test improvement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "guzzlehttp/guzzle": "~6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=4.0.0, <6.0",
+        "phpunit/phpunit": "^4.8.36, <6.0",
         "squizlabs/php_codesniffer": "1.5.*",
         "phpmd/phpmd": "2.1.*",
         "phploc/phploc": "2.0.*",

--- a/tests/Component/OrderManagement/OrderTest.php
+++ b/tests/Component/OrderManagement/OrderTest.php
@@ -22,6 +22,7 @@ namespace Klarna\Rest\Tests\Component\OrderManagement;
 use GuzzleHttp\Psr7\Response;
 use Klarna\Rest\Transport\Method;
 use Klarna\Rest\OrderManagement\Capture;
+use Klarna\Rest\OrderManagement\Refund;
 use Klarna\Rest\OrderManagement\Order;
 use Klarna\Rest\Tests\Component\ResourceTestCase;
 
@@ -80,7 +81,7 @@ JSON;
         $this->assertAuthorization($request);
 
         $capture = $order['captures'][0];
-        $this->assertInstanceOf('Klarna\Rest\OrderManagement\Capture', $capture);
+        $this->assertInstanceOf(Capture::class, $capture);
         $this->assertEquals($capture->getId(), $capture['capture_id']);
         $this->assertEquals('1002', $capture->getId());
         $this->assertEquals('data', $capture['test']);
@@ -262,7 +263,7 @@ JSON;
         $order = new Order($this->connector, '0002');
         $refund = $order->refund(['data' => 'sent in']);
 
-        $this->assertInstanceOf('Klarna\Rest\OrderManagement\Refund', $refund);
+        $this->assertInstanceOf(Refund::class, $refund);
 
         $request = $this->mock->getLastRequest();
         $this->assertEquals(Method::POST, $request->getMethod());
@@ -302,7 +303,7 @@ JSON;
         $order = new Order($this->connector, '0002');
 
         $refund = $order->fetchRefund('refund-id-123');
-        $this->assertInstanceOf('Klarna\Rest\OrderManagement\Refund', $refund);
+        $this->assertInstanceOf(Refund::class, $refund);
         $this->assertEquals(
             '/ordermanagement/v1/orders/0002/refunds/refund-id-123',
             $refund->getLocation()
@@ -357,7 +358,7 @@ JSON;
         $order->fetchRefund('refund-id-XXX');
 
         $refund = $order->fetchRefund('refund-id-123');
-        
+
         $this->assertEquals('abc', $refund['test_data']);
     }
 
@@ -376,7 +377,7 @@ JSON;
         $order = new Order($this->connector, '0002');
         $capture = $order->createCapture(['data' => 'goes here']);
 
-        $this->assertInstanceOf('Klarna\Rest\OrderManagement\Capture', $capture);
+        $this->assertInstanceOf(Capture::class, $capture);
         $this->assertEquals('http://somewhere/a-path', $capture->getLocation());
 
         $request = $this->mock->getLastRequest();
@@ -418,7 +419,7 @@ JSON;
         $order = new Order($this->connector, '0002');
 
         $capture = $order->fetchCapture('1002');
-        $this->assertInstanceOf('Klarna\Rest\OrderManagement\Capture', $capture);
+        $this->assertInstanceOf(Capture::class, $capture);
         $this->assertEquals(
             '/ordermanagement/v1/orders/0002/captures/1002',
             $capture->getLocation()
@@ -461,7 +462,7 @@ JSON;
         $order['captures'][] = $capture;
 
         $capture = $order->fetchCapture('1002');
-        $this->assertInstanceOf('Klarna\Rest\OrderManagement\Capture', $capture);
+        $this->assertInstanceOf(Capture::class, $capture);
         $this->assertEquals(
             '/ordermanagement/v1/orders/0002/captures/1002',
             $capture->getLocation()
@@ -504,7 +505,7 @@ JSON;
         $order['captures'][] = $capture;
 
         $capture = $order->fetchCapture('1003');
-        $this->assertInstanceOf('Klarna\Rest\OrderManagement\Capture', $capture);
+        $this->assertInstanceOf(Capture::class, $capture);
         $this->assertEquals(
             '/ordermanagement/v1/orders/0002/captures/1003',
             $capture->getLocation()
@@ -546,9 +547,9 @@ JSON;
         $order = new Order($this->connector, '0002');
 
         $captures = $order->fetchCaptures();
-        $this->assertEquals(2, count($captures), 'Mismatched amount of captures');
+        $this->assertCount(2, $captures, 'Mismatched amount of captures');
 
-        $this->assertInstanceOf('Klarna\Rest\OrderManagement\Capture', $captures[0]);
+        $this->assertInstanceOf(Capture::class, $captures[0]);
         $this->assertEquals(
             '/ordermanagement/v1/orders/0002/captures/1001',
             $captures[0]->getLocation()

--- a/tests/Component/Settlements/PayoutsTest.php
+++ b/tests/Component/Settlements/PayoutsTest.php
@@ -118,7 +118,7 @@ JSON;
         $payout = new Payouts($this->connector);
         $data = $payout->getAllPayouts($params);
 
-        $this->assertEquals(1, count($data['payouts']));
+        $this->assertCount(1, $data['payouts']);
         $this->assertEquals(500, $data['payouts'][0]['totals']['sale_amount']);
         $this->assertEquals(10, $data['pagination']['count']);
 
@@ -165,7 +165,7 @@ JSON;
         $payout = new Payouts($this->connector);
         $data = $payout->getSummary($params);
 
-        $this->assertEquals(2, count($data));
+        $this->assertCount(2, $data);
         $this->assertEquals(550, $data[0]['summary_total_fee_correction_amount']);
         $this->assertEquals(100, $data[1]['summary_total_fee_correction_amount']);
 

--- a/tests/Component/TestCase.php
+++ b/tests/Component/TestCase.php
@@ -19,6 +19,7 @@
 
 namespace Klarna\Rest\Tests\Component;
 
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
@@ -29,7 +30,7 @@ use SebastianBergmann\PHPLOC\Log\CSV\History;
 /**
  * Base component test case class.
  */
-class TestCase extends \PHPUnit_Framework_TestCase
+class TestCase extends PHPUnitTestCase
 {
     const USERNAME = '1234';
 

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -19,10 +19,12 @@
 
 namespace Klarna\Rest\Tests\Integration;
 
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+
 /**
  * Base unit test case class.
  */
-class TestCase extends \PHPUnit\Framework\TestCase
+class TestCase extends PHPUnitTestCase
 {
     protected $rootPath;
     protected $credentials = [];
@@ -39,7 +41,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
     {
         $this->rootPath = dirname(dirname(__DIR__));
         $this->credentials = json_decode(getenv('CREDENTIALS'), true);
-        
+
         if (empty($this->credentials)) {
             $path = $this->rootPath . '/credentials.json';
             if (file_exists($path)) {

--- a/tests/Unit/Checkout/OrderTest.php
+++ b/tests/Unit/Checkout/OrderTest.php
@@ -19,12 +19,9 @@
 
 namespace Klarna\Tests\Unit\Rest\Checkout;
 
-use GuzzleHttp\Exception\RequestException;
 use Klarna\Rest\Checkout\Order;
 use Klarna\Rest\Transport\Method;
 use Klarna\Rest\Tests\Unit\TestCase;
-use Klarna\Rest\Transport\Connector;
-use Klarna\Rest\Transport\Exception\ConnectorException;
 
 /**
  * Unit test cases for the checkout order resource.

--- a/tests/Unit/OrderManagement/CaptureTest.php
+++ b/tests/Unit/OrderManagement/CaptureTest.php
@@ -19,12 +19,9 @@
 
 namespace Klarna\Tests\Unit\Rest\OrderManagement;
 
-use GuzzleHttp\Exception\RequestException;
 use Klarna\Rest\OrderManagement\Capture;
 use Klarna\Rest\Tests\Unit\TestCase;
-use Klarna\Rest\Transport\Connector;
 use Klarna\Rest\Transport\Method;
-use Klarna\Rest\Transport\Exception\ConnectorException;
 
 /**
  * Unit test cases for the capture resource.
@@ -227,7 +224,7 @@ class CaptureTest extends TestCase
         $this->response->expects($this->any())
             ->method('getStatus')
             ->will($this->returnValue('204'));
-        
+
         $capture = new Capture($this->connector, '/orders/1');
 
         $this->setExpectedException(

--- a/tests/Unit/OrderManagement/OrderTest.php
+++ b/tests/Unit/OrderManagement/OrderTest.php
@@ -19,13 +19,10 @@
 
 namespace Klarna\Tests\Unit\Rest\OrderManagement;
 
-use GuzzleHttp\Exception\RequestException;
 use Klarna\Rest\OrderManagement\Capture;
 use Klarna\Rest\OrderManagement\Order;
 use Klarna\Rest\Tests\Unit\TestCase;
-use Klarna\Rest\Transport\Connector;
 use Klarna\Rest\Transport\Method;
-use Klarna\Rest\Transport\Exception\ConnectorException;
 
 /**
  * Unit test cases for the order resource.
@@ -691,7 +688,7 @@ class OrderTest extends TestCase
         $order = new Order($this->connector, '12345');
         $capture = $order->fetchCapture('2');
 
-        $this->assertInstanceOf('Klarna\Rest\OrderManagement\Capture', $capture);
+        $this->assertInstanceOf(Capture::class, $capture);
         $this->assertEquals('from response json', $capture['data']);
     }
 
@@ -776,7 +773,7 @@ class OrderTest extends TestCase
 
         $capture = $order->fetchCapture('2');
 
-        $this->assertInstanceOf('Klarna\Rest\OrderManagement\Capture', $capture);
+        $this->assertInstanceOf(Capture::class, $capture);
         $this->assertEquals('from response json', $capture['data']);
         $this->assertEquals('2', $capture->getId());
     }

--- a/tests/Unit/ResourceTest.php
+++ b/tests/Unit/ResourceTest.php
@@ -20,13 +20,9 @@
 namespace Klarna\Rest\Tests\Unit;
 
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\RequestException;
 use Klarna\Rest\Tests\Unit\TestCase;
 use Klarna\Rest\Transport\Connector;
-use Klarna\Rest\Transport\Exception\ConnectorException;
 use Klarna\Rest\Transport\UserAgent;
-use Klarna\Rest\Resource;
-use GuzzleHttp\Psr7\Response;
 
 /**
  * Unit test cases for the resource class.
@@ -109,7 +105,7 @@ class ResourceTest extends TestCase
     {
         $r = $this->getMockForAbstractClass('Klarna\Rest\Resource', [$this->connector]);
         $this->assertEquals(null, $r->getLocation());
-        
+
         $r->setLocation('/new/location');
         $this->assertEquals('/new/location', $r->getLocation());
     }

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -19,13 +19,14 @@
 
 namespace Klarna\Rest\Tests\Unit;
 
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 use Klarna\Rest\Transport\Connector;
 use Klarna\Rest\Transport\ApiResponse;
 
 /**
  * Base unit test case class.
  */
-class TestCase extends \PHPUnit_Framework_TestCase
+class TestCase extends PHPUnitTestCase
 {
     /**
      */

--- a/tests/Unit/Transport/ApiResponseTest.php
+++ b/tests/Unit/Transport/ApiResponseTest.php
@@ -19,12 +19,13 @@
 
 namespace Klarna\Rest\Tests\Unit\Transport;
 
+use PHPUnit\Framework\TestCase;
 use Klarna\Rest\Transport\ApiResponse;
 
 /**
  * Unit test cases for the UserAgent class.
  */
-class ApiResponseTest extends \PHPUnit_Framework_TestCase
+class ApiResponseTest extends TestCase
 {
     /**
      * Make sure the default user agent components are present.

--- a/tests/Unit/Transport/Exception/ConnectorExceptionTest.php
+++ b/tests/Unit/Transport/Exception/ConnectorExceptionTest.php
@@ -19,15 +19,13 @@
 
 namespace Klarna\Rest\Tests\Unit\Transport\Exception;
 
-use GuzzleHttp\Exception\RequestException;
+use PHPUnit\Framework\TestCase;
 use Klarna\Rest\Transport\Exception\ConnectorException;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 
 /**
  * Unit test cases for the ConnectorException.
  */
-class ConnectorExceptionTest extends \PHPUnit_Framework_TestCase
+class ConnectorExceptionTest extends TestCase
 {
     /**
      * Make sure the getters work as intended.

--- a/tests/Unit/Transport/GuzzleConnectorTest.php
+++ b/tests/Unit/Transport/GuzzleConnectorTest.php
@@ -25,7 +25,6 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use Klarna\Rest\Tests\Unit\TestCase;
 use Klarna\Rest\Transport\Connector;
-use Klarna\Rest\Transport\Exception\ConnectorException;
 use Klarna\Rest\Transport\UserAgent;
 
 /**
@@ -259,7 +258,7 @@ class GuzzleConnectorTest extends TestCase
         );
 
         $client = $connector->getClient();
-        $this->assertInstanceOf('GuzzleHttp\ClientInterface', $client);
+        $this->assertInstanceOf(ClientInterface::class, $client);
 
         $this->assertEquals(self::BASE_URL, $client->getConfig('base_uri'));
 
@@ -283,7 +282,7 @@ class GuzzleConnectorTest extends TestCase
         );
 
         $userAgent = $connector->getUserAgent();
-        $this->assertInstanceOf('Klarna\Rest\Transport\UserAgent', $userAgent);
+        $this->assertInstanceOf(UserAgent::class, $userAgent);
         $this->assertContains('Library/Klarna.kco_rest_php', strval($userAgent));
     }
 
@@ -296,7 +295,7 @@ class GuzzleConnectorTest extends TestCase
     {
         $client = $this->object->getClient();
 
-        $this->assertInstanceOf('GuzzleHttp\ClientInterface', $client);
+        $this->assertInstanceOf(ClientInterface::class, $client);
         $this->assertSame($this->client, $client);
     }
 }

--- a/tests/Unit/Transport/ResponseValidatorTest.php
+++ b/tests/Unit/Transport/ResponseValidatorTest.php
@@ -19,6 +19,7 @@
 
 namespace Klarna\Rest\Tests\Unit\Transport;
 
+use PHPUnit\Framework\TestCase;
 use Klarna\Rest\Transport\ResponseValidator;
 use Klarna\Rest\Transport\ApiResponse;
 use Psr\Http\Message\ResponseInterface;
@@ -26,7 +27,7 @@ use Psr\Http\Message\ResponseInterface;
 /**
  * Unit test cases for the ResponseValidator class.
  */
-class ResponseValidatorTest extends \PHPUnit_Framework_TestCase
+class ResponseValidatorTest extends TestCase
 {
     /**
      * @var ResponseInterface

--- a/tests/Unit/Transport/UserAgentTest.php
+++ b/tests/Unit/Transport/UserAgentTest.php
@@ -19,12 +19,13 @@
 
 namespace Klarna\Rest\Tests\Unit\Transport;
 
+use PHPUnit\Framework\TestCase;
 use Klarna\Rest\Transport\UserAgent;
 
 /**
  * Unit test cases for the UserAgent class.
  */
-class UserAgentTest extends \PHPUnit_Framework_TestCase
+class UserAgentTest extends TestCase
 {
     /**
      * @var UserAgent


### PR DESCRIPTION
# Changed log
- The `PHPUnit\Framework\TestCase` class is supported since `4.8.36` version.
- Using the `::class` to declare class instance.